### PR TITLE
Updating wave_stat step

### DIFF
--- a/ush/wave_ens_bull.sh
+++ b/ush/wave_ens_bull.sh
@@ -40,7 +40,6 @@
 #
 # 0.b External dependencies and paths
 #
-  export wgrib2=$utilexec/wgrib2
   scripname=wave_ens_bull.sh
 #
 # 0.b Date and time stuff
@@ -87,7 +86,7 @@
 # 1.a Interpolate from gribfile at model res to high resolution at buoy location 
 # (wgrib2 + IPOLATES -> bi-linear)
 #
-  $utilexec/wgrib2 ../gribfile -new_grid_winds earth \
+  $WGRIB2 ../gribfile -new_grid_winds earth \
                      -new_grid_interpolation bilinear -new_grid latlon \
                      ${blon}:2:.01 ${blat}:2:.01 grbint.${bnom} \
                      1> buoy_interp.out 2>&1
@@ -107,35 +106,35 @@
 #   
 # 1.b Extract parameters at buoy locations from higher res interpolated file 
 #
-    valpdy=(`$utilexec/wgrib2 grbint.${bnom} -match HTSGW -match mean -vt \
+    valpdy=(`$WGRIB2 grbint.${bnom} -match HTSGW -match mean -vt \
           | sed 's/[,=]/ /g' | awk '{print $NF}' | cut -c1-8`)
-    vald=(`$utilexec/wgrib2 grbint.${bnom} -match HTSGW -match mean -vt \
+    vald=(`$WGRIB2 grbint.${bnom} -match HTSGW -match mean -vt \
           | sed 's/[,=]/ /g' | awk '{print $NF}' | cut -c7-8`)
-    valt=(`$utilexec/wgrib2 grbint.${bnom} -match HTSGW -match mean -vt \
+    valt=(`$WGRIB2 grbint.${bnom} -match HTSGW -match mean -vt \
           | sed 's/[,=]/ /g' | awk '{print $NF}' | cut -c9-10`)
-    hsb=(`$utilexec/wgrib2 grbint.${bnom} -match HTSGW -match mean -lon \
+    hsb=(`$WGRIB2 grbint.${bnom} -match HTSGW -match mean -lon \
           ${blon} ${blat} | sed 's/[,=]/ /g' | awk '{print $NF}'`)
-    hspb=(`$utilexec/wgrib2 grbint.${bnom} -match HTSGW -match spread \
+    hspb=(`$WGRIB2 grbint.${bnom} -match HTSGW -match spread \
           -lon ${blon} ${blat} | sed 's/[,=]/ /g' | awk '{print $NF}'`)
-    tpb=(`$utilexec/wgrib2 grbint.${bnom} -match PERPW -match mean -lon \
+    tpb=(`$WGRIB2 grbint.${bnom} -match PERPW -match mean -lon \
           ${blon} ${blat} | sed 's/[,=]/ /g' | awk '{print $NF}'`)
-    tspb=(`$utilexec/wgrib2 grbint.${bnom} -match PERPW -match spread \
+    tspb=(`$WGRIB2 grbint.${bnom} -match PERPW -match spread \
           -lon ${blon} ${blat} | sed 's/[,=]/ /g' | awk '{print $NF}'`)
-    ub=(`$utilexec/wgrib2 grbint.${bnom} -match WIND -match mean -lon \
+    ub=(`$WGRIB2 grbint.${bnom} -match WIND -match mean -lon \
           ${blon} ${blat} | sed 's/[,=]/ /g' | awk '{print $NF}'`)
-    usb=(`$utilexec/wgrib2 grbint.${bnom} -match WIND -match spread -lon \
+    usb=(`$WGRIB2 grbint.${bnom} -match WIND -match spread -lon \
           ${blon} ${blat} | sed 's/[,=]/ /g' | awk '{print $NF}'`)
-    p1b=(`$utilexec/wgrib2 grbint.${bnom} -match HTSGW -match 'prob >0.6' \
+    p1b=(`$WGRIB2 grbint.${bnom} -match HTSGW -match 'prob >0.6' \
           -lon ${blon} ${blat} | sed 's/[,=]/ /g' | awk '{print $NF}'`)
-    p2b=(`$utilexec/wgrib2 grbint.${bnom} -match HTSGW -match 'prob >1' \
+    p2b=(`$WGRIB2 grbint.${bnom} -match HTSGW -match 'prob >1' \
           -lon ${blon} ${blat} | sed 's/[,=]/ /g' | awk '{print $NF}'`)
-    p3b=(`$utilexec/wgrib2 grbint.${bnom} -match HTSGW -match 'prob >2' \
+    p3b=(`$WGRIB2 grbint.${bnom} -match HTSGW -match 'prob >2' \
           -lon ${blon} ${blat} | sed 's/[,=]/ /g' | awk '{print $NF}'`)
-    p4b=(`$utilexec/wgrib2 grbint.${bnom} -match HTSGW -match 'prob >5.5' \
+    p4b=(`$WGRIB2 grbint.${bnom} -match HTSGW -match 'prob >5.5' \
           -lon ${blon} ${blat} | sed 's/[,=]/ /g' | awk '{print $NF}'`)
-    p5b=(`$utilexec/wgrib2 grbint.${bnom} -match HTSGW -match 'prob >7' \
+    p5b=(`$WGRIB2 grbint.${bnom} -match HTSGW -match 'prob >7' \
           -lon ${blon} ${blat} | sed 's/[,=]/ /g' | awk '{print $NF}'`)
-    p6b=(`$utilexec/wgrib2 grbint.${bnom} -match HTSGW -match 'prob >9' \
+    p6b=(`$WGRIB2 grbint.${bnom} -match HTSGW -match 'prob >9' \
           -lon ${blon} ${blat} | sed 's/[,=]/ /g' | awk '{print $NF}'`)
 #
 # Length of parameter vectors

--- a/ush/wave_ens_stat.sh
+++ b/ush/wave_ens_stat.sh
@@ -132,24 +132,12 @@
 #
   memb=`seq -w 0 ${nmembm1}`
 #
-    valtime=`$NDATE ${fhour} ${YMDH}`
+    valtime=`$NDATE ${fhour} ${CDATE}`
 
     mkdir -p ${valtime}
     cd ${valtime}
 
-    if [ $fhour -eq 0 ] ; then
-      ihr='anl'
-      hhh='000'
-    elif [ $fhour -lt 10 ] ; then
-      ihr=${fhour}' hour'
-      hhh='00'$fhour
-    elif [ $fhour -lt 100 ] ; then
-      ihr=${fhour}' hour'
-      hhh='0'$fhour
-    elif [ $fhour -ge 100 ] ; then
-      ihr=${fhour}' hour'
-      hhh=$fhour
-    fi
+    FH3=$(printf %03i $fhour)
 #
     rm -f gwes_stats.inp data_* 
 #
@@ -158,14 +146,12 @@
 #    while [ ${nme} -lt ${nmemb} ]
     for im in $membn
     do
-
-      infile=../../${para}_${im}.t${cyc}z.grib2
+      infile=../../${para}_${im}.t${cyc}z.f${FH3}.grib2
       if [ "${im}" = "00" ]
       then
 
 # 1.b.1 Generate input file for gwes_stats
-        echo $YMDH $hhh $nnip $parcode  > gwes_stats.inp
-        #echo $YMDH $ngrib $dtgh $nnip $parcode  > gwes_stats.inp
+        echo $CDATE $FH3 $nnip $parcode  > gwes_stats.inp
         echo ${nmemb}                 >> gwes_stats.inp
         echo $memb                    >> gwes_stats.inp
         echo ${scale[@]} | wc -w           >> gwes_stats.inp
@@ -205,27 +191,27 @@
 # 1.d Check for errors and move output files to tagged grib2 parameter-hour files
    if [ ! -f mean_out ]
    then
-     msg="ABNORMAL EXIT: ERR mean_out not gerenerated for ${nnip} $hhh."
+     msg="ABNORMAL EXIT: ERR mean_out not gerenerated for ${nnip} $FH3."
      postmsg "$jlogfile" "$msg"
      set +x
-     echo "--- mean_out not gerenerated for ${nnip} $hhh --- "
+     echo "--- mean_out not gerenerated for ${nnip} $FH3 --- "
      [[ "$LOUD" = YES ]] && set -x
-     echo "mean_out not gerenerated for ${nnip} $hhh" >> $wave_log
+     echo "mean_out not gerenerated for ${nnip} $FH3" >> $wave_log
      err=1;export err;err_chk
    else
-     mv -f mean_out    ${nnip}_mean.$hhh.grib2
+     mv -f mean_out    ${nnip}_mean.$FH3.grib2
    fi
    if [ ! -f spread_out ]
    then
-     msg="ABNORMAL EXIT: ERR spread_out not gerenerated for ${nnip} $hhh."
+     msg="ABNORMAL EXIT: ERR spread_out not gerenerated for ${nnip} $FH3."
      postmsg "$jlogfile" "$msg"
      set +x
-     echo "--- spread_out not gerenerated for ${nnip} $hhh --- "
+     echo "--- spread_out not gerenerated for ${nnip} $FH3 --- "
      [[ "$LOUD" = YES ]] && set -x
-     echo "spread_out not gerenerated for ${nnip} $hhh" >> $wave_log
+     echo "spread_out not gerenerated for ${nnip} $FH3" >> $wave_log
      err=1;export err;err_chk
    else
-     mv -f spread_out  ${nnip}_spread.$hhh.grib2
+     mv -f spread_out  ${nnip}_spread.$FH3.grib2
    fi
 
    nscale=`echo ${ascale[@]} | wc -w`     
@@ -233,15 +219,15 @@
    then
      if [ ! -f probab_out ]
      then
-       msg="ABNORMAL EXIT: ERR probab_out not gerenerated for ${nnip} $hhh."
+       msg="ABNORMAL EXIT: ERR probab_out not gerenerated for ${nnip} $FH3."
        postmsg "$jlogfile" "$msg"
        set +x
-       echo "--- probab_out not gerenerated for ${nnip} $hhh --- "
+       echo "--- probab_out not gerenerated for ${nnip} $FH3 --- "
        [[ "$LOUD" = YES ]] && set -x
-       echo "probab_out not gerenerated for ${nnip} $hhh" >> $wave_log
+       echo "probab_out not gerenerated for ${nnip} $FH3" >> $wave_log
        err=1;export err;err_chk
      else
-       mv -f probab_out  ${nnip}_probab.$hhh.grib2
+       mv -f probab_out  ${nnip}_probab.$FH3.grib2
      fi
    fi
 

--- a/ush/wave_grib2_sbs.sh
+++ b/ush/wave_grib2_sbs.sh
@@ -138,7 +138,7 @@
   [[ "$LOUD" = YES ]] && set -x
   ENSTAG=""
   if [ ${waveMEMB} ]; then ENSTAG=".${membTAG}${waveMEMB}" ; fi
-  outfile=${WAV_MOD_TAG}.${cycle}${ENSTAG}.${grdnam}.${grdres}.f${FH3}.grib2
+  outfile=${COMPONENTwave}.${cycle}${ENSTAG}.${grdnam}.${grdres}.f${FH3}.grib2
   $EXECcode/ww3_grib > grib2_${grdnam}_${FH3}.out 2>&1
   $WGRIB2 gribfile -set_date $CDATE -set_ftime "$fhr hour fcst" -grib ${COMOUT}/gridded/${outfile}
   err=$?


### PR DESCRIPTION
* Updating exwave_stat.sh to eliminate hardwired stuff, use parms defined in gefs_wave.parm and gefs_wave_stat.parm. 
* Updated cfp lines to streamline execution. 
* Added correct loops for generating output-time-based stats files. 
* Updated general parameters in USH scripts eliminating hardwired parms.