### PR TITLE
Add time template for FENGSHA's time-varying sediment supply map (SSM)

### DIFF
--- a/parm/chem/ExtData.other
+++ b/parm/chem/ExtData.other
@@ -11,12 +11,12 @@ TROPP            'Pa'    Y       N                  -            0.0      1.0   
 DU_SRC            NA  N Y - none none du_src     ExtData/Dust/gocart.dust_source.v5a.x1152_y721.nc
 
 # FENGSHA input files. Note: regridding should be N or E
-DU_CLAY          '1'  Y E - none none clayfrac   ExtData/Dust/FENGSHA_SOILGRIDS2017_GEFSv12_v1.0.nc
-DU_SAND          '1'  Y E - none none sandfrac   ExtData/Dust/FENGSHA_SOILGRIDS2017_GEFSv12_v1.0.nc
-DU_SILT          '1'  Y E - none none siltfrac   ExtData/Dust/FENGSHA_SOILGRIDS2017_GEFSv12_v1.0.nc
-DU_SSM           '1'  Y E - none none ssm        ExtData/Dust/FENGSHA_SOILGRIDS2017_GEFSv12_v1.0.nc
-DU_RDRAG         '1'  Y E - none none drag_part  ExtData/Dust/FENGSHA_SOILGRIDS2017_GEFSv12_v1.0.nc
-DU_UTHRES        '1'  Y E - none none uthres     ExtData/Dust/FENGSHA_SOILGRIDS2017_GEFSv12_v1.0.nc
+DU_CLAY          '1'  Y E           -          none none clayfrac   ExtData/Dust/FENGSHA_SOILGRIDS2017_GEFSv12_v1.0.nc
+DU_SAND          '1'  Y E           -          none none sandfrac   ExtData/Dust/FENGSHA_SOILGRIDS2017_GEFSv12_v1.0.nc
+DU_SILT          '1'  Y E           -          none none siltfrac   /dev/null
+DU_SSM           '1'  Y E %y4-%m2-%d2T12:00:00 none none ssm        ExtData/Dust/FENGSHA_SOILGRIDS2017_GEFSv12_v1.0.nc
+DU_RDRAG         '1'  Y E           -          none none drag_part  ExtData/Dust/FENGSHA_SOILGRIDS2017_GEFSv12_v1.0.nc
+DU_UTHRES        '1'  Y E           -          none none uthres     ExtData/Dust/FENGSHA_SOILGRIDS2017_GEFSv12_v1.0.nc
 
 #====== Sulfate Sources =================================================
 # Anthropogenic (BF & FF) emissions -- allowed to input as two layers


### PR DESCRIPTION
**Description**

This PR adds a missing time template for UFS-Aerosols' SSM input field to the ExtData resource file template.

This change is also included in the UFS weather model PR [#1071](https://github.com/ufs-community/ufs-weather-model/pull/1071) and was tested on RDHPCS platforms while developing P8b regression tests.

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
