### PR TITLE
Set prepobs and TC_tracker installs to interim branch installs

### DIFF
--- a/jobs/rocoto/prep.sh
+++ b/jobs/rocoto/prep.sh
@@ -113,15 +113,6 @@ if [[ ${MAKE_PREPBUFR} = "YES" ]]; then
         export MAKE_NSSTBUFR="NO"
     fi
 
-    export DEBUG_LEVEL="4"
-    export LOUD="YES"
-    export HOMEprepobs="${BASE_GIT}/prepobs/v1.0.1"
-    export EXECprepobs=${HOMEprepobs}/exec
-    export FIXprepobs=${HOMEprepobs}/fix
-    export SCRIPTprepobs=${HOMEprepobs}/script
-    export USHprepobs=${HOMEprepobs}/ush
-
-
     "${HOMEobsproc}/jobs/JOBSPROC_GLOBAL_PREP"
     status=$?
     [[ ${status} -ne 0 ]] && exit ${status}

--- a/modulefiles/module_base.hera.lua
+++ b/modulefiles/module_base.hera.lua
@@ -28,7 +28,7 @@ load(pathJoin("crtm", "2.4.0"))
 load(pathJoin("wgrib2", "2.0.8"))
 setenv("WGRIB2","wgrib2")
 
-prepend_path("MODULEPATH", pathJoin("/scratch1/NCEPDEV/global/glopara/git/prepobs/v1.0.1/modulefiles"))
+prepend_path("MODULEPATH", pathJoin("/scratch1/NCEPDEV/global/glopara/git/prepobs/feature-GFSv17_com_reorg/modulefiles"))
 load(pathJoin("prepobs", "1.0.1"))
 
 -- Temporary until official hpc-stack is updated

--- a/modulefiles/module_base.jet.lua
+++ b/modulefiles/module_base.jet.lua
@@ -22,4 +22,7 @@ load(pathJoin("g2tmpl", "1.10.0"))
 load(pathJoin("crtm", "2.4.0"))
 load(pathJoin("wgrib2", "2.0.8"))
 
+prepend_path("MODULEPATH", pathJoin("/lfs4/HFIP/hfv3gfs/glopara/git/prepobs/feature-GFSv17_com_reorg/modulefiles"))
+load(pathJoin("prepobs", "1.0.1"))
+
 whatis("Description: GFS run environment")

--- a/modulefiles/module_base.orion.lua
+++ b/modulefiles/module_base.orion.lua
@@ -27,7 +27,7 @@ load(pathJoin("crtm", "2.4.0"))
 load(pathJoin("wgrib2", "2.0.8"))
 setenv("WGRIB2","wgrib2")
 
-prepend_path("MODULEPATH", pathJoin("/work/noaa/global/glopara/git/prepobs/v1.0.1/modulefiles"))
+prepend_path("MODULEPATH", pathJoin("/work/noaa/global/glopara/git/prepobs/feature-GFSv17_com_reorg/modulefiles"))
 load(pathJoin("prepobs", "1.0.1"))
 
 -- Temporary until official hpc-stack is updated

--- a/modulefiles/module_base.s4.lua
+++ b/modulefiles/module_base.s4.lua
@@ -28,7 +28,7 @@ load(pathJoin("crtm", "2.4.0"))
 load(pathJoin("wgrib2", "2.0.8"))
 setenv("WGRIB2","wgrib2")
 
-prepend_path("MODULEPATH", pathJoin("/data/prod/glopara/git/prepobs/v1.0.1/modulefiles"))
+prepend_path("MODULEPATH", pathJoin("/data/prod/glopara/git/prepobs/feature-GFSv17_com_reorg/modulefiles"))
 load(pathJoin("prepobs", "1.0.1"))
 
 whatis("Description: GFS run environment")

--- a/modulefiles/module_base.wcoss2.lua
+++ b/modulefiles/module_base.wcoss2.lua
@@ -31,7 +31,7 @@ load(pathJoin("ncdiag", "1.0.0"))
 load(pathJoin("crtm", "2.4.0"))
 load(pathJoin("wgrib2", "2.0.7"))
 
-prepend_path("MODULEPATH", pathJoin("/lfs/h2/emc/global/save/emc.global/git/prepobs/v1.0.1/modulefiles"))
+prepend_path("MODULEPATH", pathJoin("/lfs/h2/emc/global/save/emc.global/git/prepobs/feature-GFSv17_com_reorg/modulefiles"))
 load(pathJoin("prepobs", "1.0.1"))
 
 whatis("Description: GFS run environment")

--- a/parm/config/config.vrfy
+++ b/parm/config/config.vrfy
@@ -66,7 +66,8 @@ fi
 # Cyclone genesis and cyclone track verification
 #-------------------------------------------------
 
-export ens_tracker_ver=v1.1.15.5
+#export ens_tracker_ver=v1.1.15.5
+export ens_tracker_ver=feature-GFSv17_com_reorg # TODO - temporary ahead of new tag/version
 export HOMEens_tracker=$BASE_GIT/TC_tracker/${ens_tracker_ver}
 
 if [ "$VRFYTRAK" = "YES" ]; then

--- a/workflow/hosts/hera.yaml
+++ b/workflow/hosts/hera.yaml
@@ -1,5 +1,4 @@
-# BASE_GIT: '/scratch1/NCEPDEV/global/glopara/git'
-BASE_GIT: '/scratch2/NCEPDEV/ensemble/save/Walter.Kolczynski/gw_external_git'
+BASE_GIT: '/scratch1/NCEPDEV/global/glopara/git'
 DMPDIR: '/scratch1/NCEPDEV/global/glopara/dump'
 PACKAGEROOT: '/scratch1/NCEPDEV/global/glopara/nwpara'
 COMROOT: '/scratch1/NCEPDEV/global/glopara/com'

--- a/workflow/hosts/orion.yaml
+++ b/workflow/hosts/orion.yaml
@@ -1,5 +1,4 @@
-# BASE_GIT: '/work/noaa/global/glopara/git'
-BASE_GIT: '/work2/noaa/global/wkolczyn/save/gw_external_git'
+BASE_GIT: '/work/noaa/global/glopara/git'
 DMPDIR: '/work/noaa/rstprod/dump'
 PACKAGEROOT: '/work/noaa/global/glopara/nwpara'
 COMROOT: '/work/noaa/global/glopara/com'


### PR DESCRIPTION
**Description**

This PR includes updates for interim prepobs and TC_tracker external packages that support the COM reorg. Changes included:

1. Set `ens_tracker_ver=feature-GFSv17_com_reorg` until official tag is installed on supported platforms. Have follow-up PR for that.
2. Set prepobs install path in `module_base` modulefiles to the interim `feature-GFSv17_com_reorg` install.
3. Remove prepobs path variables from `jobs/rocoto/prep.sh` that override what the module sets. Also remove temporary testing settings (`DEBUG_LEVEL` and `LOUD`).
4. Revert `BASE_GIT` paths in Hera and Orion hosts files back to global group space locations.

**Type of change**

Further external package updates.

**How Has This Been Tested?**

- [x] Cycled test on Orion
  
Refs #761
