### PR TITLE
Run the metp jobs with one task each

### DIFF
--- a/parm/config/gfs/config.resources
+++ b/parm/config/gfs/config.resources
@@ -988,8 +988,8 @@ case ${step} in
     threads_per_task=1
     walltime_gdas="03:00:00"
     walltime_gfs="06:00:00"
-    ntasks=4
-    tasks_per_node=4
+    ntasks=1
+    tasks_per_node=1
     export memory="80G"
     ;;
 


### PR DESCRIPTION
This effectively disable MPMD for the METplus jobs.